### PR TITLE
Fix VoxWriter incorrect errno usage on Unix

### DIFF
--- a/VoxWriter.cpp
+++ b/VoxWriter.cpp
@@ -675,7 +675,7 @@ namespace vox
 		lastError = fopen_s(&m_File, vFilePathName.c_str(), "wb");
 #else
         m_File = fopen(vFilePathName.c_str(), "wb");
-        lastError = errno;
+        lastError = m_File ? 0 : errno;
 #endif
 		if (lastError != 0)
 			return false;


### PR DESCRIPTION
A non-null return from `fopen` already implies no error, while `errno` may not have been reset and could still be non-zero.

This was causing a write to fail when there were no actual IO errors.