### PR TITLE
Improve handling of voxels with negative coordinates

### DIFF
--- a/VoxWriter.cpp
+++ b/VoxWriter.cpp
@@ -507,7 +507,7 @@ namespace vox
 		m_MaxVoxelPerCubeZ = ct::clamp<int32_t>(vMaxVoxelPerCubeZ, 0, 126);
 
 		maxVolume.lowerBound = 1e7f;
-		maxVolume.upperBound = 0.0f;
+		maxVolume.upperBound = -1e7f;
 	}
 
 	VoxWriter::~VoxWriter()
@@ -718,6 +718,17 @@ namespace vox
 		return cubesId[vX][vY][vZ];
 	}
 
+	// Wrap a position inside a particular cube dimension
+	inline uint8_t Wrap(int v, int lim)
+	{
+		v = v % lim;
+		if (v < 0)
+		{
+			v += lim;
+		}
+		return (uint8_t)v;
+	}
+
 	void VoxWriter::MergeVoxelInCube(const int32_t& vX, const int32_t& vY, const int32_t& vZ, const uint8_t& vColorIndex, VoxCube *vCube)
 	{
 		maxVolume.Combine(ct::dvec3((double)vX, (double)vY, (double)vZ));
@@ -737,12 +748,12 @@ namespace vox
 
 		if (exist == false)
 		{
-			vCube->xyzi.voxels.push_back((uint8_t)(vX % m_MaxVoxelPerCubeX)); // x
-			vCube->xyzi.voxels.push_back((uint8_t)(vY % m_MaxVoxelPerCubeY)); // y
-			vCube->xyzi.voxels.push_back((uint8_t)(vZ % m_MaxVoxelPerCubeZ)); // z
+			vCube->xyzi.voxels.push_back(Wrap(vX, m_MaxVoxelPerCubeX)); // x
+			vCube->xyzi.voxels.push_back(Wrap(vY, m_MaxVoxelPerCubeY)); // y
+			vCube->xyzi.voxels.push_back(Wrap(vZ, m_MaxVoxelPerCubeZ)); // z
 
 			// correspond a la loc de la couleur du voxel en question
-			voxelId[vX][vY][vZ] = vCube->xyzi.voxels.size();
+			voxelId[vX][vY][vZ] = (int)vCube->xyzi.voxels.size();
 
 			vCube->xyzi.voxels.push_back(vColorIndex); // color index
 		}


### PR DESCRIPTION
Consider a box that spans the following coordinates: (-200, 0, 0) (-100, 50, 20). This box would span two cubes because it's wider than 126. The output should be two cubes at (-252, 0, 0) and (-126, 0, 0) and the voxels should form a contiguous box.

However, because the wrapping of the voxels is broken right now, the voxels get written into the .vox file with coordinates that exceed 126 due to wrapping on the `uint8_t`. This has one of two effects: (1) the voxels exceed the bounds of the parent cube, and/or (2) MagicaVox crashes.

Wrapping the voxels correctly inside the cube produces the correct output and prevents the crash.

Without this fix, the only workaround is to force users of the library to shift all their voxels into a positive coordinate space, which seems unnecessary. This fix is especially convenient for people working with geometry that has its origin around (0,0,0), e.g. game models, as the geometry is likely to extend out from (0,0,0) in all directions.

Broken case. Note how the box is broken up, and the left box exceeds the cube bounds.
![Broken case](https://user-images.githubusercontent.com/1682617/221688547-5e97f0d9-588b-4aff-8087-8676b1c9989d.png)

Fixed case. The voxels are correctly aligned contiguously.
![Fixed](https://user-images.githubusercontent.com/1682617/221688625-4412540d-89d8-4803-9198-fc9fe857302f.png)
