### PR TITLE
Better way to detect MSVC

### DIFF
--- a/VoxWriter.cpp
+++ b/VoxWriter.cpp
@@ -671,7 +671,7 @@ namespace vox
 
 	bool VoxWriter::OpenFileForWriting(const std::string& vFilePathName)
 	{
-#ifdef MSVC
+#if _MSC_VER
 		lastError = fopen_s(&m_File, vFilePathName.c_str(), "wb");
 #else
         m_File = fopen(vFilePathName.c_str(), "wb");


### PR DESCRIPTION
Visual studio compiling is better detected with 

`#if _MSC_VER`

instead of

`#ifdef MSVC`

Using this fix, the safer "fopen_s" functionality is used to get a file handle.